### PR TITLE
feat: remove engine from API and depend on psycopg3 in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ from pg_force_execute import pg_force_execute
 # Run postgresql locally should allow the below to run
 # docker run --rm -it -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres
 
-engine = sa.create_engine('postgresql://postgres@127.0.0.1:5432/')
+engine = sa.create_engine('postgresql+psycopg://postgres@127.0.0.1:5432/')
 query = 'SELECT 1'  # A more realistic example would be something that needs an exclusive lock on a table
 
 with \
         engine.begin() as conn, \
         pg_force_execute(
             conn,           # SQLAlchemy connection to run the query
-            engine,         # SQLAlchemy engine that will create new connections to cancel blocking queries
             delay=datetime.timedelta(minutes=5),  # Amount of time to wait before cancelling queries
         ):
 
@@ -45,8 +44,6 @@ The API a single context manager `pg_force_execute`.
 `pg_force_execute`(conn, engine, delay=datetime.timedelta(minutes=5), check_interval=datetime.timedelta(seconds=1), termination_thread_timeout=datetime.timedelta(seconds=10), logger=logging.getLogger("pg_force_execute"))
 
 - `conn` - A [SQLAlchemy connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) that will be unblocked
-
-- `engine` - A [SQLAlchemy engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) to create a new connection that will be used to terminate backends blocking `conn`
 
 - `delay` (optional) - How long to wait before attempting to terminate backends blocking `conn`
 

--- a/pg_force_execute.py
+++ b/pg_force_execute.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 @contextlib.contextmanager
-def pg_force_execute(conn, engine,
+def pg_force_execute(conn,
                      delay=datetime.timedelta(minutes=5),
                      check_interval=datetime.timedelta(seconds=1),
                      termination_thread_timeout=datetime.timedelta(seconds=10),
@@ -26,12 +26,12 @@ def pg_force_execute(conn, engine,
             # that get blocked by clients not caught in the initial pg_blocking_pids call
             while not exit.wait(timeout=check_interval.total_seconds()):
                 logger.info('Cancelling queries blocking PID %s', pid)
-                with engine.begin() as conn:
+                with conn.engine.begin() as _conn:
                     # pg_cancel_backend isn't strong enough - the blocking PIDs might not be
                     # actually running a query, so there is nothing to cancel. They might
                     # just be holding locks. To force release of the locks, we have to call
                     # pg_terminate_backend
-                    cancelled_queries = conn.execute(
+                    cancelled_queries = _conn.execute(
                         sa.text("""
                             SELECT
                                 activity.usename AS usename,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "psycopg2-binary>=2.8.6",
+    "psycopg[binary]>=3.1.9",
     "pytest>=7.2.1",
 ]
 


### PR DESCRIPTION
Removing enging required changing the test that asserted on errors from cancelling being propagated. To allow proper dynamic SQL in the test, this required using psycopg directly (escaping identifiers doesn't seem to be part of SQLAlchemy strangely), and so thought may as well use psycopg3