### PR TITLE
feat: support only SQLAlchemy 1.4.24 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ with \
 
 - Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
 - psycopg2 >= 2.9.2 or Psycopg 3 >= 3.1.4
-- SQLAlchemy >= 1.4.0 (tested on 1.4.0 and 2.0.0)
+- SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, and 15.0)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "sqlalchemy>=1.4.0",
+    "sqlalchemy>=1.4.24",
 ]
 
 [project.optional-dependencies]
@@ -31,7 +31,7 @@ ci = [
 ]
 ci-psycopg2-sqlalchemy1 = [
     "psycopg2==2.9.2",
-    "sqlalchemy==1.4.0",
+    "sqlalchemy==1.4.24",
 ]
 ci-psycopg2-sqlalchemy2 = [
     "psycopg2==2.9.2",

--- a/test_pg_force_execute.py
+++ b/test_pg_force_execute.py
@@ -15,10 +15,6 @@ except ImportError:
     from psycopg2 import sql
     engine_type = 'postgresql+psycopg2'
 
-get_connection = \
-    (lambda conn: conn.connection.driver_connection) if tuple(int(v) for v in sa.__version__.split('.')) >= (2,0,0) else \
-    (lambda conn: conn.connection.connection)
-
 from pg_force_execute import pg_force_execute
 
 # Run postgresql locally should allow the below to run
@@ -97,7 +93,7 @@ def test_cancel_exception_propagates():
             pass
 
     with engine.begin() as conn:
-        driver_connection = get_connection(conn)
+        driver_connection = conn.connection.driver_connection
         conn.execute(sa.text("DROP TABLE IF EXISTS pg_force_execute_test;"))
         conn.execute(sa.text("CREATE TABLE pg_force_execute_test(id int);"))
         conn.execute(sa.text(sql.SQL("CREATE USER {} PASSWORD 'password';").format(sql.Identifier(user)).as_string(driver_connection)))


### PR DESCRIPTION
This is the version that added driver_connection, which continues on in SQLAlchemy 2 (originally thought it was 2.0.0, but it wasn't it's 1.4.24). Doing this for simplicity - not worth the complexity to support the older version